### PR TITLE
fix: skip DCA schedule creation when storage fallback returns null

### DIFF
--- a/indexers/liquidity-pools/src/handlers/dca/dcaSchedule.ts
+++ b/indexers/liquidity-pools/src/handlers/dca/dcaSchedule.ts
@@ -170,7 +170,7 @@ export async function handleDcaScheduleCreated(
     }),
   };
 
-  if (!callArgs) return;
+  if (!callArgs || !callArgs.scheduleData) return;
 
   const newSchedule = await createDcaSchedule({
     ctx,


### PR DESCRIPTION
## Problem

The processor crashed with:

```
TypeError: Cannot destructure property 'owner' of 'scheduleData' as it is null.
    at createDcaSchedule (src/handlers/dca/dcaSchedule.ts)
    at handleDcaScheduleCreated
```

When a `DCA.Scheduled` event has no decodable call args (created inside a batch/nested call), `handleDcaScheduleCreated` falls back to reading the schedule from chain storage. That storage read returns `null` when the schedule no longer exists at the block (e.g. created and terminated/completed in the same block). The fallback wraps it as `{ scheduleData: null }`, and the existing guard `if (!callArgs) return;` never caught it because the wrapper object is truthy — only the inner `scheduleData` was null. The null then propagated into `createDcaSchedule`, which destructures `owner` off it and threw.

## Fix

Guard now also returns when the resolved inner `scheduleData` is null, so unresolvable schedules are skipped instead of crashing the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)